### PR TITLE
Refactor Navbar component to use Link for logo navigation

### DIFF
--- a/client/src/components/common/Navbar.jsx
+++ b/client/src/components/common/Navbar.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react"; // hamburger + close icons
 import avatar from "/avatars/1.png";
 
@@ -19,13 +19,18 @@ export default function Navbar() {
       <div className="flex items-center justify-between px-6 py-4">
         {/* Logo */}
         <div className="flex items-center">
-          <img src="/logo.png" alt="logo" className="w-10 h-10 mt-1.5" />
-          <h1 className="ml-2 text-2xl font-silkscreen">
-            GUES
-            <span className="text-[#FFFB00] drop-shadow-[0_0_5px_#FFFB00]">
-              SYNC
-            </span>
-          </h1>
+          <Link to="/landing" className="flex items-center">
+            <img src="/logo.png" alt="logo" className="w-10 h-10 mt-1.5" />
+          </Link>
+
+          <Link to="/landing" className="flex items-center">
+            <h1 className="ml-2 text-2xl font-silkscreen">
+              GUES
+              <span className="text-[#FFFB00] drop-shadow-[0_0_5px_#FFFB00]">
+                SYNC
+              </span>
+            </h1>
+          </Link>
         </div>
 
         {/* Desktop Menu */}


### PR DESCRIPTION
Added navigation route for Navbar logo and title to redirected to Home page
<img width="1056" height="349" alt="Screenshot 2025-10-02 at 10 28 24" src="https://github.com/user-attachments/assets/a6b61e14-fb41-4a97-8f62-3fc05984c78f" />
<img width="2048" height="200" alt="Untitled design (5)" src="https://github.com/user-attachments/assets/2fbe94d6-a069-4d1d-b231-c09c56ca8161" />
